### PR TITLE
merge modified changes to steem.js 

### DIFF
--- a/src/auth/ecc/src/key_public.js
+++ b/src/auth/ecc/src/key_public.js
@@ -22,10 +22,20 @@ class PublicKey {
   }
 
   static fromBuffer(buffer) {
+    if (
+      buffer.toString("hex") ===
+        "000000000000000000000000000000000000000000000000000000000000000000"
+       )
+      return new PublicKey(null);
     return new PublicKey(ecurve.Point.decodeFrom(secp256k1, buffer));
   }
 
-  toBuffer(compressed = this.Q.compressed) {
+   toBuffer(compressed = this.Q ? this.Q.compressed : null) {
+     if (this.Q === null)
+       return Buffer.from(
+         "000000000000000000000000000000000000000000000000000000000000000000",
+         "hex"
+        );
     return this.Q.getEncoded(compressed);
   }
 

--- a/test/KeyFormats.js
+++ b/test/KeyFormats.js
@@ -69,6 +69,16 @@ const test = function (key) {
       const address = Address.fromPublic(public_key, true, 56);
       assert.equal(key.Compressed_PTS, address.toString());
     });
+    
+    it("null hex to pubkey", function() {
+      const public_key = PublicKey.fromHex(key.null_hex);
+      assert.equal(key.null_address, public_key.toPublicKeyString());
+    });
+    
+    it("null pubkey to hex", function() {
+      const public_key = PublicKey.fromString(key.null_address);
+      assert.equal(key.null_hex, public_key.toHex());
+    });
   });
 };
 
@@ -86,5 +96,8 @@ test({
   Uncompressed_BTC: 'SCRLAFmEtM8as1mbmjVcj5dphLdPguXquimn',
   Compressed_BTC: 'SCRANNTSEaUviJgWLzJBersPmyFZBY4jJETY',
   Uncompressed_PTS: 'SCREgj7RM6FBwSoccGaESJLC3Mi18785bM3T',
-  Compressed_PTS: 'SCRD5rYtofD6D4UHJH6mo953P5wpBfMhdMEi'
+  Compressed_PTS:	"SCRD5rYtofD6D4UHJH6mo953P5wpBfMhdMEi",
+    // https://github.com/steemit/steem-js/issues/267
+    null_hex: "000000000000000000000000000000000000000000000000000000000000000000",
+    null_address: "SCR1111111111111111111111111111111114T1Anm"
 });


### PR DESCRIPTION
This PR, mergers the Netuoso PR 267 from steem.js, which allows for sending disable keys to using scorum.js to disable a witness, using third party apps

See steem.js PR #267 for background